### PR TITLE
Fix Arrow Leak error

### DIFF
--- a/src/chart_plugin/systems/arrows.rs
+++ b/src/chart_plugin/systems/arrows.rs
@@ -72,6 +72,7 @@ pub fn create_arrow_end(
                         arrow_type: event.arrow_type,
                     },
                 );
+                break
             }
         }
     }


### PR DESCRIPTION
@nx2k3 we definitely need to add unit tests 😄 

I've got `19683` arrows created with freezed app without this `break`.