### PR TITLE
Do not save hidden arrows

### DIFF
--- a/src/chart_plugin/systems/save.rs
+++ b/src/chart_plugin/systems/save.rs
@@ -35,7 +35,7 @@ pub fn save_json(
         ),
         With<Rectangle>,
     >,
-    arrows: Query<&ArrowMeta, With<ArrowMeta>>,
+    arrows: Query<(&ArrowMeta, &Visibility), With<ArrowMeta>>,
     request: Res<SaveRequest>,
     mut app_state: ResMut<AppState>,
     text_query: Query<&mut Text, With<EditableText>>,
@@ -90,8 +90,10 @@ pub fn save_json(
     }
 
     let json_arrows = json["arrows"].as_array_mut().unwrap();
-    for arrow_meta in arrows.iter() {
-        json_arrows.push(json!(arrow_meta));
+    for (arrow_meta, visibility) in arrows.iter() {
+        if visibility != Visibility::Hidden {
+            json_arrows.push(json!(arrow_meta));
+        }
     }
 
     let doc = if request.doc_id.is_some() {


### PR DESCRIPTION
that will help wasm target to save some space in localStorage. 