### PR TITLE
Fix click-based interactions

### DIFF
--- a/src/ui_plugin/systems/resize_node.rs
+++ b/src/ui_plugin/systems/resize_node.rs
@@ -82,122 +82,118 @@ pub fn resize_entity_run(
 ) {
     let (camera, camera_transform) = camera_q.single();
 
-    if !cursor_moved_events.is_empty() {
-        let event = cursor_moved_events.iter().last().unwrap();
-        if let Some(id) = ui_state.entity_to_resize {
-            for (raw_text_parent, raw_text, mut cosmic_edit, mut sprite) in
-                &mut raw_text_query.iter_mut()
+    if let Some(id) = ui_state.entity_to_resize {
+        for (raw_text_parent, raw_text, mut cosmic_edit, mut sprite) in
+            &mut raw_text_query.iter_mut()
+        {
+            if id != raw_text.id {
+                continue;
+            }
+            let event = cursor_moved_events.iter().last();
+            if let Some(cursor_pos) = event
+                .and_then(|event| camera.viewport_to_world_2d(camera_transform, event.position))
             {
-                if id != raw_text.id {
-                    continue;
+                let (border_parent, velo_border, mut path) =
+                    border_query.get_mut(raw_text_parent.get()).unwrap();
+                let (velo_transform, children) =
+                    velo_node_query.get_mut(border_parent.get()).unwrap();
+                let pos = velo_transform.translation.truncate();
+                let mut width = f32::max(((cursor_pos.x - pos.x).abs() * 2.).round(), 1.);
+                let mut height = f32::max(((cursor_pos.y - pos.y).abs() * 2.).round(), 1.);
+                if velo_border.node_type == NodeType::Circle {
+                    width = f32::max(width, height);
+                    height = f32::max(width, height);
                 }
-                if let Some(cursor_pos) =
-                    camera.viewport_to_world_2d(camera_transform, event.position)
-                {
-                    let (border_parent, velo_border, mut path) =
-                        border_query.get_mut(raw_text_parent.get()).unwrap();
-                    let (velo_transform, children) =
-                        velo_node_query.get_mut(border_parent.get()).unwrap();
-                    let pos = velo_transform.translation.truncate();
-                    let mut width = f32::max(((cursor_pos.x - pos.x).abs() * 2.).round(), 1.);
-                    let mut height = f32::max(((cursor_pos.y - pos.y).abs() * 2.).round(), 1.);
-                    if velo_border.node_type == NodeType::Circle {
-                        width = f32::max(width, height);
-                        height = f32::max(width, height);
-                    }
-                    if width % 2.0 != 0.0 {
-                        width += 1.0;
-                    }
-                    if height % 2.0 != 0.0 {
-                        height += 1.0;
-                    }
+                if width % 2.0 != 0.0 {
+                    width += 1.0;
+                }
+                if height % 2.0 != 0.0 {
+                    height += 1.0;
+                }
 
-                    cosmic_edit.width = width;
-                    cosmic_edit.height = height;
-                    sprite.custom_size = Some(Vec2::new(width, height));
-                    cosmic_edit.editor.buffer_mut().set_redraw(true);
+                cosmic_edit.width = width;
+                cosmic_edit.height = height;
+                sprite.custom_size = Some(Vec2::new(width, height));
+                cosmic_edit.editor.buffer_mut().set_redraw(true);
 
-                    for child in children.iter() {
-                        // update resize markers positions
-                        if let Ok(resize) = resize_marker_query.get_mut(*child) {
-                            let mut resize_transform = resize.2;
-                            match resize.0 {
-                                ResizeMarker::TopLeft => {
-                                    resize_transform.translation.x = -width / 2.;
-                                    resize_transform.translation.y = height / 2.;
-                                }
-                                ResizeMarker::TopRight => {
-                                    resize_transform.translation.x = width / 2.;
-                                    resize_transform.translation.y = height / 2.;
-                                }
-                                ResizeMarker::BottomLeft => {
-                                    resize_transform.translation.x = -width / 2.;
-                                    resize_transform.translation.y = -height / 2.;
-                                }
-                                ResizeMarker::BottomRight => {
-                                    resize_transform.translation.x = width / 2.;
-                                    resize_transform.translation.y = -height / 2.;
-                                }
+                for child in children.iter() {
+                    // update resize markers positions
+                    if let Ok(resize) = resize_marker_query.get_mut(*child) {
+                        let mut resize_transform = resize.2;
+                        match resize.0 {
+                            ResizeMarker::TopLeft => {
+                                resize_transform.translation.x = -width / 2.;
+                                resize_transform.translation.y = height / 2.;
                             }
-                        }
-                        // update arrow connectors positions
-                        if let Ok(arrow_connect) = arrow_connector_query.get_mut(*child) {
-                            let mut arrow_transform = arrow_connect.1;
-                            match arrow_connect.0.pos {
-                                crate::canvas::arrow::components::ArrowConnectPos::Top => {
-                                    arrow_transform.translation.x = 0.;
-                                    arrow_transform.translation.y = height / 2.;
-                                }
-                                crate::canvas::arrow::components::ArrowConnectPos::Bottom => {
-                                    arrow_transform.translation.x = 0.;
-                                    arrow_transform.translation.y = -height / 2.;
-                                }
-                                crate::canvas::arrow::components::ArrowConnectPos::Left => {
-                                    arrow_transform.translation.x = -width / 2.;
-                                    arrow_transform.translation.y = 0.;
-                                }
-                                crate::canvas::arrow::components::ArrowConnectPos::Right => {
-                                    arrow_transform.translation.x = width / 2.;
-                                    arrow_transform.translation.y = 0.;
-                                }
+                            ResizeMarker::TopRight => {
+                                resize_transform.translation.x = width / 2.;
+                                resize_transform.translation.y = height / 2.;
+                            }
+                            ResizeMarker::BottomLeft => {
+                                resize_transform.translation.x = -width / 2.;
+                                resize_transform.translation.y = -height / 2.;
+                            }
+                            ResizeMarker::BottomRight => {
+                                resize_transform.translation.x = width / 2.;
+                                resize_transform.translation.y = -height / 2.;
                             }
                         }
                     }
-
-                    // update size of bevy_lyon node
-                    let points = [
-                        Vec2::new(-width / 2., -height / 2.),
-                        Vec2::new(-width / 2., height / 2.),
-                        Vec2::new(width / 2., height / 2.),
-                        Vec2::new(width / 2., -height / 2.),
-                    ];
-
-                    let new_path = match velo_border.node_type {
-                        NodeType::Rect => bevy_prototype_lyon::prelude::GeometryBuilder::build_as(
-                            &bevy_prototype_lyon::shapes::RoundedPolygon {
-                                points: points.into_iter().collect(),
-                                closed: true,
-                                radius: 10.,
-                            },
-                        ),
-                        NodeType::Paper => bevy_prototype_lyon::prelude::GeometryBuilder::build_as(
-                            &bevy_prototype_lyon::shapes::Polygon {
-                                points: points.into_iter().collect(),
-                                closed: true,
-                            },
-                        ),
-                        NodeType::Circle => {
-                            bevy_prototype_lyon::prelude::GeometryBuilder::build_as(
-                                &bevy_prototype_lyon::shapes::Circle {
-                                    radius: width / 2.,
-                                    center: Vec2::new(0., 0.),
-                                },
-                            )
+                    // update arrow connectors positions
+                    if let Ok(arrow_connect) = arrow_connector_query.get_mut(*child) {
+                        let mut arrow_transform = arrow_connect.1;
+                        match arrow_connect.0.pos {
+                            crate::canvas::arrow::components::ArrowConnectPos::Top => {
+                                arrow_transform.translation.x = 0.;
+                                arrow_transform.translation.y = height / 2.;
+                            }
+                            crate::canvas::arrow::components::ArrowConnectPos::Bottom => {
+                                arrow_transform.translation.x = 0.;
+                                arrow_transform.translation.y = -height / 2.;
+                            }
+                            crate::canvas::arrow::components::ArrowConnectPos::Left => {
+                                arrow_transform.translation.x = -width / 2.;
+                                arrow_transform.translation.y = 0.;
+                            }
+                            crate::canvas::arrow::components::ArrowConnectPos::Right => {
+                                arrow_transform.translation.x = width / 2.;
+                                arrow_transform.translation.y = 0.;
+                            }
                         }
-                    };
-                    *path = new_path;
-                    events.send(RedrawArrow { id: raw_text.id });
+                    }
                 }
+
+                // update size of bevy_lyon node
+                let points = [
+                    Vec2::new(-width / 2., -height / 2.),
+                    Vec2::new(-width / 2., height / 2.),
+                    Vec2::new(width / 2., height / 2.),
+                    Vec2::new(width / 2., -height / 2.),
+                ];
+
+                let new_path = match velo_border.node_type {
+                    NodeType::Rect => bevy_prototype_lyon::prelude::GeometryBuilder::build_as(
+                        &bevy_prototype_lyon::shapes::RoundedPolygon {
+                            points: points.into_iter().collect(),
+                            closed: true,
+                            radius: 10.,
+                        },
+                    ),
+                    NodeType::Paper => bevy_prototype_lyon::prelude::GeometryBuilder::build_as(
+                        &bevy_prototype_lyon::shapes::Polygon {
+                            points: points.into_iter().collect(),
+                            closed: true,
+                        },
+                    ),
+                    NodeType::Circle => bevy_prototype_lyon::prelude::GeometryBuilder::build_as(
+                        &bevy_prototype_lyon::shapes::Circle {
+                            radius: width / 2.,
+                            center: Vec2::new(0., 0.),
+                        },
+                    ),
+                };
+                *path = new_path;
+                events.send(RedrawArrow { id: raw_text.id });
             }
         }
     }

--- a/src/ui_plugin/systems/update_rectangle_position.rs
+++ b/src/ui_plugin/systems/update_rectangle_position.rs
@@ -17,21 +17,21 @@ pub fn update_rectangle_position(
     ui_state: Res<UiState>,
 ) {
     let (camera, camera_transform) = camera_q.single();
-    if !cursor_moved_events.is_empty() {
-        let event = cursor_moved_events.iter().last().unwrap();
-        for (raw_text, parent) in &mut raw_text_query.iter() {
-            if !ui_state.drawing_mode
-                && ui_state.modal_id.is_none()
-                && Some(raw_text.id) == ui_state.hold_entity
-                && ui_state.entity_to_edit.is_none()
+    for (raw_text, parent) in &mut raw_text_query.iter() {
+        if !ui_state.drawing_mode
+            && ui_state.modal_id.is_none()
+            && Some(raw_text.id) == ui_state.hold_entity
+            && ui_state.entity_to_edit.is_none()
+        {
+            let event = cursor_moved_events.iter().last();
+            if let Some(pos) = event
+                .and_then(|event| camera.viewport_to_world_2d(camera_transform, event.position))
             {
-                if let Some(pos) = camera.viewport_to_world_2d(camera_transform, event.position) {
-                    let border = border_query.get(parent.get()).unwrap();
-                    let mut top = velo_node_query.get_mut(border.get()).unwrap();
-                    top.translation.x = pos.x.round();
-                    top.translation.y = pos.y.round();
-                    events.send(RedrawArrow { id: raw_text.id });
-                }
+                let border = border_query.get(parent.get()).unwrap();
+                let mut top = velo_node_query.get_mut(border.get()).unwrap();
+                top.translation.x = pos.x.round();
+                top.translation.y = pos.y.round();
+                events.send(RedrawArrow { id: raw_text.id });
             }
         }
     }


### PR DESCRIPTION
Click-based interactions don't work correctly on my Windows machine. This relates to checking for cursor moved events (currently the code bails out if there are no events), as these cursor moved events don't fire very often and this makes for poor UX as it is difficult to resize, move, or select notes.

I remove/reducing checking of whether there are cursor moved events. Where they are relevant (resizing, for example), they remain when converting window coordinates to world space coordinates.