### PR TITLE
increase universe size

### DIFF
--- a/src/canvas/grid/systems.rs
+++ b/src/canvas/grid/systems.rs
@@ -5,37 +5,60 @@ use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 
 const CELL_SIZE: f32 = 12.0;
 
+#[derive(Component)]
+pub struct Grid;
+
 pub fn grid(
     mut commands: Commands,
     mut materials: ResMut<Assets<CustomGridMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
     theme: Res<Theme>,
 ) {
-    let max_size = theme.max_grid_size;
+    let max_size = 1_000_000.;
     let size = Vec2::new(max_size, max_size);
     let mesh = Mesh::from(shape::Quad { size, flip: false });
 
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(mesh).into(),
-        transform: Transform {
-            translation: Vec3::new(0.0, 0.0, 0.0),
+    commands
+        .spawn(MaterialMesh2dBundle {
+            mesh: meshes.add(mesh).into(),
+            transform: Transform {
+                translation: Vec3::new(0.0, 0.0, 0.0),
+                ..Default::default()
+            },
+            material: materials.add(CustomGridMaterial {
+                line_color: theme.canvas_bg_line_color,
+                grid_size: size,
+                cell_size: Vec2::splat(CELL_SIZE),
+                major: 4.0,
+            }),
             ..Default::default()
-        },
-        material: materials.add(CustomGridMaterial {
-            line_color: theme.canvas_bg_line_color,
-            grid_size: size,
-            cell_size: Vec2::splat(CELL_SIZE),
-            major: 4.0,
-        }),
-        ..Default::default()
-    });
+        })
+        .insert(Grid);
 }
 
 pub fn update_camera_translation(
-    mut query: Query<&mut Transform, (Changed<Transform>, With<OrthographicProjection>)>,
+    mut query: Query<
+        (&mut Transform, &OrthographicProjection),
+        (
+            Or<(Changed<Transform>, Changed<OrthographicProjection>)>,
+            With<OrthographicProjection>,
+        ),
+    >,
+    mut grid_q: Query<
+        (&mut Transform, &mut Visibility),
+        (With<Grid>, Without<OrthographicProjection>),
+    >,
 ) {
-    for mut transform in query.iter_mut() {
+    for (mut transform, proj) in query.iter_mut() {
         transform.translation = transform.translation.round();
+        let (mut grid_transform, mut grid_visibility) = grid_q.single_mut();
+        if proj.scale > 500. {
+            grid_transform.translation.x = transform.translation.x;
+            grid_transform.translation.y = transform.translation.y;
+            *grid_visibility = Visibility::Hidden;
+        } else {
+            *grid_visibility = Visibility::Visible;
+        }
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -25,7 +25,7 @@ pub fn setup_camera(mut commands: Commands, theme: Res<Theme>) {
         main_camera.camera_2d.clear_color = ClearColorConfig::Custom(Color::WHITE.with_a(0.1));
     }
 
-    let max_size = theme.max_grid_size;
+    let max_size = theme.max_camera_space;
     commands.spawn((main_camera, MainCamera)).insert(PanCam {
         grab_buttons: vec![MouseButton::Right],
         enabled: true,

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -34,7 +34,7 @@ pub struct Theme {
     pub left_panel_bg: Color,
     pub line_height: f32,
     pub link: Color,
-    pub max_grid_size: f32,
+    pub max_camera_space: f32,
     pub menu_bg: Color,
     pub menu_btn_bg: Color,
     pub menu_btn: Color,
@@ -118,7 +118,7 @@ pub fn velo_light() -> Theme {
         tab_bg: Color::rgb(0.9, 0.9, 0.9),
         text_pos_btn_bg: Color::rgb(207.0 / 255.0, 216.0 / 255.0, 220.0 / 255.0),
         tooltip_bg: Color::rgb(1., 1., 1.),
-        max_grid_size: 1_000_000.,
+        max_camera_space: 1_000_000_000_000.,
     }
 }
 
@@ -179,7 +179,7 @@ pub fn velo_dark() -> Theme {
         tab_bg: Color::rgb(0.2, 0.2, 0.2),
         text_pos_btn_bg: Color::rgb(0.9, 0.9, 0.9),
         tooltip_bg: Color::rgb(0.2, 0.2, 0.2),
-        max_grid_size: 1_000_000.,
+        max_camera_space: 1_000_000_000_000.,
     }
 }
 


### PR DESCRIPTION
It's not perfect solution from UX point of view, grid is hidden on big zoom out. But the size of universe is extended to 1 trillion x 1 trillion. Default paper-like note is 144x144, so universe can contain ~ 48 quintillions of notes.