### PR TITLE
shortcuts - add new paper note

### DIFF
--- a/src/ui_plugin/systems/keyboard.rs
+++ b/src/ui_plugin/systems/keyboard.rs
@@ -22,9 +22,12 @@ use crate::{
     themes::Theme,
     utils::{bevy_color_to_cosmic, ReflectableUuid},
     AddRect, UiState,
+    JsonNode,
+    NodeType, 
+    JsonNodeText
 };
 
-use super::{ui_helpers::{Drawing, EditableText, InteractiveNode}, JsonNode, NodeType, JsonNodeText};
+use super::ui_helpers::{Drawing, EditableText, InteractiveNode};
 use crate::resources::{AppState, SaveDocRequest};
 
 #[path = "../../macros.rs"]

--- a/src/ui_plugin/systems/keyboard.rs
+++ b/src/ui_plugin/systems/keyboard.rs
@@ -21,10 +21,7 @@ use crate::{
     resources::{LoadTabRequest, SaveTabRequest},
     themes::Theme,
     utils::{bevy_color_to_cosmic, ReflectableUuid},
-    AddRect, UiState,
-    JsonNode,
-    NodeType, 
-    JsonNodeText
+    AddRect, UiState, JsonNode, JsonNodeText, NodeType
 };
 
 use super::ui_helpers::{Drawing, EditableText, InteractiveNode};
@@ -141,7 +138,7 @@ pub fn keyboard_input_system(
                     pos: crate::TextPos::Center,
                 },
                 bg_color: pair_struct!(theme.paper_node_bg),
-                ..default()
+                ..Default::default()
             },
             image: None,
         });

--- a/src/ui_plugin/systems/keyboard.rs
+++ b/src/ui_plugin/systems/keyboard.rs
@@ -24,7 +24,7 @@ use crate::{
     AddRect, UiState,
 };
 
-use super::ui_helpers::{Drawing, EditableText, InteractiveNode};
+use super::{ui_helpers::{Drawing, EditableText, InteractiveNode}, JsonNode, NodeType, JsonNodeText};
 use crate::resources::{AppState, SaveDocRequest};
 
 #[path = "../../macros.rs"]
@@ -124,6 +124,24 @@ pub fn keyboard_input_system(
                 });
             }
         }
+    } else if command && input.just_pressed(KeyCode::P) {
+        events.send(AddRect {
+            node: JsonNode {
+                id: Uuid::new_v4(),
+                node_type: NodeType::Paper,
+                x,
+                y,
+                width: theme.node_width,
+                height: theme.node_height,
+                text: JsonNodeText {
+                    text: "".to_string(),
+                    pos: crate::TextPos::Center,
+                },
+                bg_color: pair_struct!(theme.paper_node_bg),
+                ..default()
+            },
+            image: None,
+        });
     } else {
         for (editable_text, mut cosmic_edit, mut cosmit_edit_history) in
             &mut editable_text_query.iter_mut()
@@ -182,8 +200,6 @@ pub fn insert_from_clipboard(
     scale_factor: f64,
     theme: &Res<Theme>,
 ) {
-    use crate::JsonNode;
-
     if let Ok(mut clipboard) = arboard::Clipboard::new() {
         if let Ok(image) = clipboard.get_image() {
             let image: RgbaImage = ImageBuffer::from_raw(

--- a/src/ui_plugin/systems/keyboard.rs
+++ b/src/ui_plugin/systems/keyboard.rs
@@ -21,7 +21,7 @@ use crate::{
     resources::{LoadTabRequest, SaveTabRequest},
     themes::Theme,
     utils::{bevy_color_to_cosmic, ReflectableUuid},
-    AddRect, UiState, JsonNode, JsonNodeText, NodeType
+    AddRect, JsonNode, JsonNodeText, NodeType, UiState,
 };
 
 use super::ui_helpers::{Drawing, EditableText, InteractiveNode};


### PR DESCRIPTION
Hi, this is my first PR and also first for anything Rust related, very new to Rust 😅 also I'm in love with this project feel like I can learn a lot just by contributing to this project.
So for this PR I just kind of copy paste the paper note insertion handler implementation from `button_handlers.rs`. I don't know where should I create a reusable function for this one, please let me know how I can improve this if you have time. thank you! 